### PR TITLE
[refactor] Use exchange interface instead of function pointers

### DIFF
--- a/src/exchanges/binance.cpp
+++ b/src/exchanges/binance.cpp
@@ -1,33 +1,27 @@
-#include "binance.h"
-#include "parameters.h"
-#include "utils/restapi.h"
-#include "unique_json.hpp"
-#include "hex_str.hpp"
-#include "time_fun.h"
-#include "openssl/sha.h"
-#include "openssl/hmac.h"
 #include <array>
 #include <algorithm>
 #include <ctime>
 #include <cctype>
 #include <cstdlib>
 #include <iomanip>
+#include "binance.h"
+#include "hex_str.hpp"
+#include "time_fun.h"
+#include "openssl/sha.h"
+#include "openssl/hmac.h"
 
-namespace Binance
+namespace NSExchange
 {
 
-static json_t *authRequest(Parameters &, std::string, std::string, std::string);
-
-static std::string getSignature(Parameters &params, std::string payload);
-
-static RestApi &queryHandle(Parameters &params)
+RestApi& Binance::queryHandle(Parameters &params)
 {
     static RestApi query("https://api.binance.com",
                          params.cacert.c_str(), *params.logFile);
     return query;
 }
 
-std::string getMatchingPair(std::string pair) {
+std::string Binance::getMatchingPair(std::string pair)
+{
   if (pair.compare("btcusd") == 0) {
     return "BTCUSDT";
   } else if (pair.compare("ethusd") == 0) {
@@ -41,7 +35,7 @@ std::string getMatchingPair(std::string pair) {
   }
 }
 
-quote_t getQuote(Parameters &params, std::string pair)
+quote_t Binance::getQuote(Parameters &params, std::string pair)
 {
 
     std::string matchingPair = getMatchingPair(pair);
@@ -64,7 +58,7 @@ quote_t getQuote(Parameters &params, std::string pair)
     return std::make_pair(bidValue, askValue);
 }
 
-double getAvail(Parameters &params, std::string currency)
+double Binance::getAvail(Parameters &params, std::string currency)
 {
     std::string cur_str;
     //cur_str += "symbol=BTCUSDT";
@@ -102,7 +96,7 @@ double getAvail(Parameters &params, std::string currency)
     return available;
 }
 
-std::string sendLongOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair)
+std::string Binance::sendLongOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair)
 {
     if (direction.compare("buy") != 0 && direction.compare("sell") != 0)
     {
@@ -134,12 +128,12 @@ std::string sendLongOrder(Parameters &params, std::string direction, double quan
 }
 
 //TODO: probably not necessary
-std::string sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair)
+std::string Binance::sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair)
 {
     return "0";
 }
 
-bool isOrderComplete(Parameters &params, std::string orderId)
+bool Binance::isOrderComplete(Parameters &params, std::string orderId)
 {
     unique_json root{authRequest(params, "GET", "/api/v3/openOrders", "")};
     size_t arraySize = json_array_size(root.get());
@@ -160,12 +154,12 @@ bool isOrderComplete(Parameters &params, std::string orderId)
     return complete;
 }
 
-double getActivePos(Parameters &params, std::string currency)
+double Binance::getActivePos(Parameters &params, std::string currency)
 {
     return getAvail(params, currency);
 }
 
-double getLimitPrice(Parameters &params, double volume, bool isBid, std::string pair)
+double Binance::getLimitPrice(Parameters &params, double volume, bool isBid, std::string pair)
 {
 
     std::string matchingPair = getMatchingPair(pair);
@@ -197,7 +191,7 @@ double getLimitPrice(Parameters &params, double volume, bool isBid, std::string 
     return p;
 }
 
-json_t *authRequest(Parameters &params, std::string method, std::string request, std::string options)
+json_t* Binance::authRequest(Parameters &params, std::string method, std::string request, std::string options)
 {
     //create timestamp Binance is annoying and requires their servertime
     auto &exchange = queryHandle(params);
@@ -237,7 +231,7 @@ json_t *authRequest(Parameters &params, std::string method, std::string request,
     }
 }
 
-static std::string getSignature(Parameters &params, std::string payload)
+std::string Binance::getSignature(Parameters &params, std::string payload)
 {
     uint8_t *hmac_digest = HMAC(EVP_sha256(),
                                 params.binanceSecret.c_str(), params.binanceSecret.size(),
@@ -247,7 +241,7 @@ static std::string getSignature(Parameters &params, std::string payload)
     return api_sign_header;
 }
 
-void testBinance()
+void Binance::testBinance()
 {
 
     Parameters params("blackbird.conf");
@@ -274,4 +268,5 @@ void testBinance()
     //std::cout << "Sell order is complete: " << isOrderComplete(params, orderId) << std::endl;
     //std::cout << "Active Position: " << getActivePos(params,orderId.c_str());
 }
-}
+
+} //namespace NSExchange

--- a/src/exchanges/binance.h
+++ b/src/exchanges/binance.h
@@ -1,29 +1,50 @@
+/*
+ * @file     binance.h
+ * @brief    Provides the interface to for exchanging using Binance.
+ */
+
 #ifndef BINANCE_H
 #define BINANCE_H
 
-#include "quote_t.h"
 #include <string>
+#include "iExchange.h"
+#include "utils/restapi.h"
+#include "unique_json.hpp"
 
-struct Parameters;
-
-namespace Binance
+namespace NSExchange
 {
 
-quote_t getQuote(Parameters &params, std::string pair);
+/**
+ * @brief Binance is an implementation of IExchange interface. https://www.binance.com/
+ */
+class Binance : public IExchange
+{
+	virtual ~Binance() = default;
 
-double getAvail(Parameters &params, std::string currency);
+	quote_t getQuote(Parameters &params, std::string pair) override final;
 
-std::string sendLongOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair);
+	double getAvail(Parameters &params, std::string currency) override final;
 
-std::string sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendLongOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair) override final;
 
-bool isOrderComplete(Parameters &params, std::string orderId);
+	std::string sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair) override final;
 
-double getActivePos(Parameters &params, std::string currency);
+	bool isOrderComplete(Parameters &params, std::string orderId) override final;
 
-double getLimitPrice(Parameters &params, double volume, bool isBid, std::string pair);
+	double getActivePos(Parameters &params, std::string currency) override final;
 
-void testBinance();
-}
+	double getLimitPrice(Parameters &params, double volume, bool isBid, std::string pair) override final;
 
-#endif
+	static json_t* authRequest(Parameters &, std::string, std::string, std::string);
+
+	static std::string getSignature(Parameters &params, std::string payload);
+
+	static RestApi& queryHandle(Parameters &params);
+
+	std::string getMatchingPair(std::string pair);
+
+	void testBinance();
+};
+
+} //namespace NSExchange
+#endif /* BINANCE_H */

--- a/src/exchanges/bitfinex.h
+++ b/src/exchanges/bitfinex.h
@@ -1,32 +1,51 @@
+/*
+ * @file     bitfinex.h
+ * @brief    Provides the interface to for exchanging using Bitfinex
+ */
+
 #ifndef BITFINEX_H
 #define BITFINEX_H
 
-#include "quote_t.h"
 #include <string>
+#include "iExchange.h"
+#include "quote_t.h"
+#include "utils/restapi.h"
+#include "unique_json.hpp"
 
-struct json_t;
-struct Parameters;
+namespace NSExchange
+{
 
-namespace Bitfinex {
+/**
+ * @brief Bitfinex is an implementation of IExchange interface. https://www.bitfinex.com/
+ */
+class Bitfinex : public IExchange
+{
+    virtual ~Bitfinex() = default;
 
-quote_t getQuote(Parameters &params, std::string pair);
+	quote_t getQuote(Parameters &params, std::string pair) override final;
 
-double getAvail(Parameters& params, std::string currency);
+	double getAvail(Parameters& params, std::string currency) override final;
 
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-std::string sendOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
 
-bool isOrderComplete(Parameters& params, std::string orderId);
+	bool isOrderComplete(Parameters& params, std::string orderId) override final;
 
-double getActivePos(Parameters& params, std::string currency);
+	double getActivePos(Parameters& params, std::string currency) override final;
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair);
+	double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) override final;
 
-json_t* authRequest(Parameters &params, std::string request, std::string options);
+	json_t* authRequest(Parameters &params, std::string request, std::string options);
 
-}
+	static RestApi& queryHandle(Parameters &params);
 
-#endif
+	static json_t* checkResponse(std::ostream &logFile, json_t *root);
+
+	std::string getMatchingPair(std::string pair);
+};
+
+} //namespace NSExchange
+#endif /* BITFINEX_H */

--- a/src/exchanges/bitstamp.h
+++ b/src/exchanges/bitstamp.h
@@ -1,27 +1,46 @@
+/*
+ * @file     bitstamp.h
+ * @brief    Provides the interface to for exchanging using Bitstamp.
+ */
+
 #ifndef BITSTAMP_H
 #define BITSTAMP_H
 
-#include "quote_t.h"
-
 #include <string>
+#include "iExchange.h"
+#include "quote_t.h"
+#include "unique_json.hpp"
+#include "utils/restapi.h"
 
-struct json_t;
-struct Parameters;
+namespace NSExchange
+{
 
-namespace Bitstamp {
+/**
+ * @brief Bitstamp is an implementation of IExchange interface. https://www.bitstamp.net/
+ */
+class Bitstamp : public IExchange
+{
+	virtual ~Bitstamp() = default;
 
-quote_t getQuote(Parameters& params, std::string pair);
+	quote_t getQuote(Parameters& params, std::string pair) override final;
 
-double getAvail(Parameters& params, std::string currency);
+	double getAvail(Parameters& params, std::string currency) override final;
 
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-bool isOrderComplete(Parameters& params, std::string orderId);
+	std::string sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair) override final;
 
-double getActivePos(Parameters& params, std::string currency);
+	bool isOrderComplete(Parameters& params, std::string orderId) override final;
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair);
+	double getActivePos(Parameters& params, std::string currency) override final;
 
-}
+	double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) override final;
 
-#endif
+	static json_t* authRequest(Parameters &, std::string, std::string);
+	static RestApi& queryHandle(Parameters &params);
+	static json_t* checkResponse(std::ostream &logFile, json_t *root);
+	std::string getMatchingPair(std::string pair);
+};
+
+} //namespace NSExchange
+#endif /* BITSTAMP_H */

--- a/src/exchanges/bittrex.h
+++ b/src/exchanges/bittrex.h
@@ -1,28 +1,46 @@
+/*
+ * @file     bittrex.h
+ * @brief    Provides the interface to for exchanging using Bittrex.
+ */
+
 #ifndef BITTREX_H
 #define BITTREX_H
 
-#include "quote_t.h"
 #include <string>
+#include "iExchange.h"
+#include "quote_t.h"
+#include "utils/restapi.h"
+#include "unique_json.hpp"
 
-struct Parameters;
+namespace NSExchange
+{
 
-namespace Bittrex {
+/**
+ * @brief Bittrex is an implementation of IExchange interface. https://bittrex.com
+ */
+class Bittrex : public IExchange
+{
+	quote_t getQuote(Parameters &params, std::string pair) override final;
 
-quote_t getQuote(Parameters &params, std::string pair);
+	double getAvail(Parameters& params, std::string currency) override final;
 
-double getAvail(Parameters& params, std::string currency);
+	std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	bool isOrderComplete(Parameters& params, std::string orderId) override final;
 
-bool isOrderComplete(Parameters& params, std::string orderId);
+	double getActivePos(Parameters& params, std::string currency) override final;
 
-double getActivePos(Parameters& params, std::string currency);
+	double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) override final;
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair);
+	void testBittrex();
 
-void testBittrex();
-}
+	std::string sendOrder(Parameters& params, std::string direction, double quantity, double price);
+	static json_t* authRequest(Parameters &, std::string, std::string);
+	static RestApi& queryHandle(Parameters &params);
+	static json_t* checkResponse(std::ostream &logFile, json_t *root);
+};
 
-#endif
+} //namespace NSExchange
+#endif /* BITTREX_H */

--- a/src/exchanges/btce.h
+++ b/src/exchanges/btce.h
@@ -1,25 +1,47 @@
+/*
+ * @file     btce.h
+ * @brief    Provides the interface to for exchanging using Btce.
+ */
+
 #ifndef BTCE_H
 #define BTCE_H
 
-#include "quote_t.h"
 #include <string>
+#include "iExchange.h"
+#include "quote_t.h"
+#include "utils/restapi.h"
+#include "unique_json.hpp"
 
-struct Parameters;
+namespace NSExchange
+{
 
-namespace BTCe {
+/**
+ * @brief BTCe is an implementation of IExchange interface. https://wex.nz
+ */
+class BTCe : public IExchange
+{
+	virtual ~BTCe() = default;
 
-quote_t getQuote(Parameters &params, std::string pair);
+	quote_t getQuote(Parameters &params, std::string pair) override final;
 
-double getAvail(Parameters& params, std::string currency);
+	double getAvail(Parameters& params, std::string currency) override final;
 
-std::string sendLongOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendLongOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair) override final;
 
-bool isOrderComplete(Parameters& params, std::string orderId);
+	std::string sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair) override final;
 
-double getActivePos(Parameters& params, std::string currency);
+	bool isOrderComplete(Parameters& params, std::string orderId) override final;
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair);
+	double getActivePos(Parameters& params, std::string currency) override final;
 
-}
+	double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) override final;
 
-#endif
+
+	static json_t* authRequest(Parameters &, const char *, const std::string & = "");
+	static json_t* adjustResponse(json_t *);
+	static RestApi& queryHandle(Parameters &params);
+	static json_t* checkResponse(std::ostream &logFile, json_t *root);
+};
+
+} //namespace NSExchange
+#endif /* BTCE_H */

--- a/src/exchanges/cexio.h
+++ b/src/exchanges/cexio.h
@@ -1,38 +1,59 @@
+/*
+ * @file     cexio.h
+ * @brief    Provides the interface to for exchanging using Cexio.
+ */
+
 #ifndef CEXIO_H
 #define CEXIO_H
 
-#include "quote_t.h"
 #include <string>
 #include <sstream>
-
-struct json_t;
-struct Parameters;
-
-namespace Cexio {
-
-quote_t getQuote(Parameters &params, std::string pair);
-
-double getAvail(Parameters& params, std::string currency);
-
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
-
-std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
-
-std::string sendOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
-
-std::string openPosition(Parameters& params,std::string direction, double quantity, double price, std::string pair);
-
-std::string closePosition(Parameters& params, std::string pair);
+#include "iExchange.h"
+#include "quote_t.h"
+#include "unique_json.hpp"
+#include "utils/restapi.h"
 
 
-bool isOrderComplete(Parameters& params, std::string orderId);
+namespace NSExchange
+{
 
-double getActivePos(Parameters& params, std::string currency);
+/**
+ * @brief Cexio is an implementation of IExchange interface. https://cex.io/
+ */
+class Cexio : public IExchange
+{
+	virtual ~Cexio() = default;
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair);
+	quote_t getQuote(Parameters &params, std::string pair) override final;
 
-void testCexio();
+	double getAvail(Parameters& params, std::string currency) override final;
 
-}
+	std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-#endif
+	std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
+
+	std::string sendOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+
+	std::string openPosition(Parameters& params,std::string direction, double quantity, double price, std::string pair);
+
+	std::string closePosition(Parameters& params, std::string pair);
+
+	bool isOrderComplete(Parameters& params, std::string orderId) override final;
+
+	double getActivePos(Parameters& params, std::string currency) override final;
+
+	double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) override final;
+
+	static json_t* authRequest(Parameters &, std::string, std::string);
+	static RestApi& queryHandle(Parameters &params);
+	static json_t* checkResponse(std::ostream &logFile, json_t *root);
+	std::string getMatchingPair(std::string pair);
+	std::string getTickerPair(std::string pair);
+	int getMatchingSymbols(std::string pair, std::string symbols[]);
+
+	void testCexio();
+
+};
+
+} //namespace NSExchange
+#endif /* CEXIO_H */

--- a/src/exchanges/exmo.h
+++ b/src/exchanges/exmo.h
@@ -1,32 +1,52 @@
+/*
+ * @file     exmo.h
+ * @brief    Provides the interface to for exchanging using Exmo.
+ */
+
 #ifndef EXMO_H
 #define EXMO_H
 
-#include "quote_t.h"
 #include <string>
 #include <sstream>
 #include <algorithm>
+#include "iExchange.h"
+#include "quote_t.h"
+#include "utils/restapi.h"
+#include "unique_json.hpp"
 
-struct json_t;
-struct Parameters;
+namespace NSExchange
+{
 
-namespace Exmo {
+/**
+ * @brief Exmo is an implementation of IExchange interface. https://exmo.com
+ */
+class Exmo : public IExchange
+{
+	virtual ~Exmo() = default;
 
-quote_t getQuote(Parameters &params, std::string pair);
+	quote_t getQuote(Parameters &params, std::string pair) override final;
 
-double getAvail(Parameters& params, std::string currency);
+	double getAvail(Parameters& params, std::string currency) override final;
 
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
-// TODO multi currency support
-//std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair = "btc_usd");
+	std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-bool isOrderComplete(Parameters& params, std::string orderId);
+	// TODO multi currency support
+	//std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair = "btc_usd");
 
-double getActivePos(Parameters& params, std::string currency);
+	std::string sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair) override final;
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair);
+	bool isOrderComplete(Parameters& params, std::string orderId) override final;
 
-void testExmo();
+	double getActivePos(Parameters& params, std::string currency) override final;
 
-}
+	double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) override final;
 
-#endif
+	void testExmo();
+
+	static json_t* authRequest(Parameters &, const char* URL_Request, std::string URL_Options = "");
+	static std::string getSignature(Parameters &, std::string);
+	static RestApi& queryHandle(Parameters &params);
+};
+
+} //namespace NSExchange
+#endif /* EXMO_H */

--- a/src/exchanges/gdax.cpp
+++ b/src/exchanges/gdax.cpp
@@ -11,17 +11,17 @@
 #include <ctime>
 #include <cmath>
 
-namespace GDAX
+namespace NSExchange
 {
 
-static RestApi &queryHandle(Parameters &params)
+RestApi& GDAX::queryHandle(Parameters &params)
 {
   static RestApi query("https://api.gdax.com",
                        params.cacert.c_str(), *params.logFile);
   return query;
 }
 
-quote_t getQuote(Parameters &params, std::string pair)
+quote_t GDAX::getQuote(Parameters &params, std::string pair)
 {
   auto &exchange = queryHandle(params);
   std::string req;
@@ -42,7 +42,7 @@ quote_t getQuote(Parameters &params, std::string pair)
   return std::make_pair(std::stod(bid), std::stod(ask));
 }
 
-double getAvail(Parameters &params, std::string currency)
+double GDAX::getAvail(Parameters &params, std::string currency)
 {
   unique_json root{authRequest(params, "GET", "/accounts", "")};
   size_t arraySize = json_array_size(root.get());
@@ -68,13 +68,13 @@ double getAvail(Parameters &params, std::string currency)
   return available;
 }
 
-double getActivePos(Parameters &params, std::string pair)
+double GDAX::getActivePos(Parameters &params, std::string pair)
 {
   // TODO: this is not really a good way to get active positions
   return getAvail(params, "BTC");
 }
 
-double getLimitPrice(Parameters &params, double volume, bool isBid, std::string pair)
+double GDAX::getLimitPrice(Parameters &params, double volume, bool isBid, std::string pair)
 {
   auto &exchange = queryHandle(params);
   // TODO: Build a real URL with leg1 leg2 and auth post it
@@ -100,7 +100,7 @@ double getLimitPrice(Parameters &params, double volume, bool isBid, std::string 
   return p;
 }
 
-std::string sendLongOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair)
+std::string GDAX::sendLongOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair)
 {
   if (direction.compare("buy") != 0 && direction.compare("sell") != 0)
   {
@@ -122,7 +122,13 @@ std::string sendLongOrder(Parameters &params, std::string direction, double quan
   return txid;
 }
 
-bool isOrderComplete(Parameters &params, std::string orderId)
+std::string GDAX::sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair)
+{
+  //TODO
+  return "0";
+}
+
+bool GDAX::isOrderComplete(Parameters &params, std::string orderId)
 {
 
   unique_json root{authRequest(params, "GET", "/orders", "")};
@@ -142,7 +148,7 @@ bool isOrderComplete(Parameters &params, std::string orderId)
   return complete;
 }
 
-json_t *authRequest(Parameters &params, std::string method, std::string request, const std::string &options)
+json_t* GDAX::authRequest(Parameters &params, std::string method, std::string request, const std::string &options)
 {
   // create timestamp
 
@@ -196,9 +202,9 @@ json_t *authRequest(Parameters &params, std::string method, std::string request,
     exit(0);
   }
 }
-std::string gettime()
-{
 
+std::string GDAX::gettime()
+{
   timeval curTime;
   gettimeofday(&curTime, NULL);
   int milli = curTime.tv_usec / 1000;
@@ -219,7 +225,8 @@ std::string gettime()
   snprintf(buff5, 40, "%lld.%d000", result2, milli);
   return buff5;
 }
-void testGDAX()
+
+void GDAX::testGDAX()
 {
 
   Parameters params("bird.conf");
@@ -246,4 +253,5 @@ void testGDAX()
   //std::cout << "Sell order is complete: " << isOrderComplete(params, orderId) << std::endl;
   //std::cout << "Active Position: " << getActivePos(params);
 }
-}
+
+} //namespace NSExchange

--- a/src/exchanges/gdax.h
+++ b/src/exchanges/gdax.h
@@ -1,32 +1,49 @@
+/*
+ * @file     gdax.h
+ * @brief    Provides the interface to for exchanging using GDAX.
+ */
+
 #ifndef GDAX_H
 #define GDAX_H
 
-#include "quote_t.h"
 #include <string>
+#include "iExchange.h"
+#include "quote_t.h"
+#include "utils/restapi.h"
+#include "unique_json.hpp"
 
-struct json_t;
-struct Parameters;
+namespace NSExchange
+{
 
-namespace GDAX {
+/**
+ * @brief GDAX is an implementation of IExchange interface. https://www.gdax.com
+ */
+class GDAX : public IExchange
+{
+	virtual ~GDAX() = default;
 
-quote_t getQuote(Parameters &params, std::string pair);
+	quote_t getQuote(Parameters &params, std::string pair) override final;
 
-double getAvail(Parameters& params, std::string currency);
+	double getAvail(Parameters& params, std::string currency) override final;
 
-double getActivePos(Parameters& params, std::string currency);
+	double getActivePos(Parameters& params, std::string currency) override final;
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair);
+	double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) override final;
 
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-bool isOrderComplete(Parameters& params, std::string orderId);
+	std::string sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair) override final;
 
-json_t* authRequest(Parameters& params, std::string method, std::string request,const std::string &options);
+	bool isOrderComplete(Parameters& params, std::string orderId) override final;
 
-std::string gettime();
+	json_t* authRequest(Parameters& params, std::string method, std::string request,const std::string &options);
 
-void testGDAX();
+	std::string gettime();
 
-}
+	void testGDAX();
 
-#endif
+	static RestApi& queryHandle(Parameters &params);
+};
+
+} //namespace NSExchange
+#endif /* GDAX_H */

--- a/src/exchanges/gemini.h
+++ b/src/exchanges/gemini.h
@@ -1,28 +1,47 @@
+/*
+ * @file     gemini.h
+ * @brief    Provides the interface to for exchanging using Gemini.
+ */
+
 #ifndef GEMINI_H
 #define GEMINI_H
 
-#include "quote_t.h"
 #include <string>
+#include <sstream>
+#include "iExchange.h"
+#include "quote_t.h"
+#include "utils/restapi.h"
+#include "unique_json.hpp"
 
-struct json_t;
-struct Parameters;
+namespace NSExchange
+{
 
-namespace Gemini {
+/**
+ * @brief Gemini is an implementation of IExchange interface. https://gemini.com/
+ */
+class Gemini : public IExchange
+{
+	virtual ~Gemini() = default;
 
-quote_t getQuote(Parameters &params, std::string pair);
+	quote_t getQuote(Parameters &params, std::string pair) override final;
 
-double getAvail(Parameters& params, std::string currency);
+	double getAvail(Parameters& params, std::string currency) override final;
 
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-bool isOrderComplete(Parameters& params, std::string orderId);
+	std::string sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair) override final;
 
-double getActivePos(Parameters& params, std::string currency);
+	bool isOrderComplete(Parameters& params, std::string orderId) override final;
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair);
+	double getActivePos(Parameters& params, std::string currency) override final;
 
-json_t* authRequest(Parameters& params, std::string url, std::string request, std::string options);
+	double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) override final;
 
-}
+	json_t* authRequest(Parameters& params, std::string url, std::string request, std::string options);
 
-#endif
+	static RestApi& queryHandle(Parameters &params);
+};
+
+} //namespace NSExchange
+#endif /* GEMINI_H */
+

--- a/src/exchanges/iExchange.h
+++ b/src/exchanges/iExchange.h
@@ -1,0 +1,40 @@
+/**
+ * @file iExchange.h
+ * @brief IExhange provides the interface for exchanging.
+ */
+
+#ifndef IEXCHANGE_H
+#define IEXCHANGE_H
+
+#include <string>
+#include "quote_t.h"
+#include "parameters.h"
+
+// TODO: check const-correctness
+namespace NSExchange
+{
+
+/**
+ * @brief Interface for exchanging
+ */
+struct IExchange
+{
+    virtual ~IExchange() = default;
+
+	virtual quote_t getQuote(Parameters &params, std::string pair) = 0;
+
+	virtual double getAvail(Parameters &params, std::string currency) = 0;
+
+	virtual std::string sendLongOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair) = 0;
+
+	virtual std::string sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair) = 0;
+
+	virtual bool isOrderComplete(Parameters &params, std::string orderId) = 0;
+
+	virtual double getActivePos(Parameters &params, std::string currency) = 0;
+
+	virtual double getLimitPrice(Parameters &params, double volume, bool isBid, std::string pair) = 0;
+};
+
+} //namespace NSExchange
+#endif /* IEXCHANGE_H */

--- a/src/exchanges/itbit.cpp
+++ b/src/exchanges/itbit.cpp
@@ -5,16 +5,16 @@
 #include "unique_json.hpp"
 
 
-namespace ItBit {
+namespace NSExchange {
 
-static RestApi& queryHandle(Parameters &params)
+RestApi& ItBit::queryHandle(Parameters &params)
 {
   static RestApi query ("https://api.itbit.com",
                         params.cacert.c_str(), *params.logFile);
   return query;
 }
 
-quote_t getQuote(Parameters &params, std::string pair)
+quote_t ItBit::getQuote(Parameters &params, std::string pair)
 {
   auto &exchange = queryHandle(params);
   unique_json root { exchange.getRequest("/v1/markets/XBTUSD/ticker") };
@@ -28,19 +28,40 @@ quote_t getQuote(Parameters &params, std::string pair)
   return std::make_pair(bidValue, askValue);
 }
 
-double getAvail(Parameters& params, std::string currency) {
+double ItBit::getAvail(Parameters& params, std::string currency)
+{
   // TODO
   return 0.0;
 }
 
-double getActivePos(Parameters& params, std::string currency) {
+double ItBit::getActivePos(Parameters& params, std::string currency)
+{
   // TODO
   return 0.0;
 }
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) {
+double ItBit::getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair)
+{
   // TODO
   return 0.0;
 }
 
+std::string ItBit::sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair)
+{
+  //TODO
+  return "0";
 }
+
+std::string ItBit::sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair)
+{
+  //TODO
+  return "0";
+}
+
+bool ItBit::isOrderComplete(Parameters& params, std::string orderId)
+{
+  //TODO
+  return false;
+}
+
+} //namespace NSExchange

--- a/src/exchanges/itbit.h
+++ b/src/exchanges/itbit.h
@@ -1,22 +1,43 @@
+/*
+ * @file     itbit.h
+ * @brief    Provides the interface to for exchanging using itBit.
+ */
+
 #ifndef ITBIT_H
 #define ITBIT_H
 
-#include "quote_t.h"
 #include <string>
+#include <sstream>
+#include "iExchange.h"
+#include "quote_t.h"
+#include "utils/restapi.h"
 
-struct json_t;
-struct Parameters;
+namespace NSExchange
+{
 
-namespace ItBit {
+/**
+ * @brief ItBit is an implementation of IExchange interface. https://www.itbit.com/
+ */
+class ItBit : public IExchange
+{
+	virtual ~ItBit() = default;
 
-quote_t getQuote(Parameters &params, std::string pair);
+	quote_t getQuote(Parameters &params, std::string pair) override final;
 
-double getAvail(Parameters& params, std::string currency);
+	double getAvail(Parameters& params, std::string currency) override final;
 
-double getActivePos(Parameters& params, std::string currency);
+	double getActivePos(Parameters& params, std::string currency) override final;
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair);
+	double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) override final;
 
-}
+	std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-#endif
+	std::string sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair) override final;
+
+	bool isOrderComplete(Parameters& params, std::string orderId) override final;
+
+	static RestApi& queryHandle(Parameters &params);
+};
+
+} //namespace NSExchange
+#endif /* ITBIT_H */

--- a/src/exchanges/kraken.h
+++ b/src/exchanges/kraken.h
@@ -1,34 +1,50 @@
+/*
+ * @file     kraken.h
+ * @brief    Provides the interface to for exchanging using Kraken.
+ */
+
 #ifndef KRAKEN_H
 #define KRAKEN_H
 
-#include "quote_t.h"
 #include <string>
+#include "iExchange.h"
+#include "quote_t.h"
+#include "unique_json.hpp"
+#include "utils/restapi.h"
 
-struct json_t;
-struct Parameters;
+namespace NSExchange
+{
 
-namespace Kraken {
+/**
+ * @brief Kraken is an implementation of IExchange interface. https://www.kraken.com/
+ */
+class Kraken : public IExchange
+{
+    virtual ~Kraken() = default;
 
-quote_t getQuote(Parameters& params, std::string pair);
+	quote_t getQuote(Parameters& params, std::string pair) override final;
 
-double getAvail(Parameters& params, std::string currency);
+	double getAvail(Parameters& params, std::string currency) override final;
 
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-std::string sendOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
 
-bool isOrderComplete(Parameters& params, std::string orderId);
+	bool isOrderComplete(Parameters& params, std::string orderId) override final;
 
-double getActivePos(Parameters& params, std::string currency);
+	double getActivePos(Parameters& params, std::string currency) override final;
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair);
+	double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) override final;
 
-json_t* authRequest(Parameters& params, std::string request, std::string options = "");
+	json_t* authRequest(Parameters& params, std::string request, std::string options = "");
 
-void testKraken();
+	static RestApi& queryHandle(Parameters &params);
+	std::string getMatchingPair(std::string pair);
 
-}
+	void testKraken();
+};
 
-#endif
+} //namespace NSExchange
+#endif /* KRAKEN_H */

--- a/src/exchanges/okcoin.cpp
+++ b/src/exchanges/okcoin.cpp
@@ -12,16 +12,17 @@
 #include <thread>   // sleep_for
 #include <cmath>    // fabs
 
-namespace OKCoin {
+namespace NSExchange
+{
 
-static RestApi& queryHandle(Parameters &params)
+RestApi& OKCoin::queryHandle(Parameters &params)
 {
   static RestApi query ("https://www.okcoin.com",
                         params.cacert.c_str(), *params.logFile);
   return query;
 }
 
-quote_t getQuote(Parameters &params, std::string pair)
+quote_t OKCoin::getQuote(Parameters &params, std::string pair)
 {
   auto &exchange = queryHandle(params);
   unique_json root { exchange.getRequest("/api/ticker.do?ok=1") };
@@ -34,7 +35,7 @@ quote_t getQuote(Parameters &params, std::string pair)
   return std::make_pair(bidValue, askValue);
 }
 
-double getAvail(Parameters& params, std::string currency)
+double OKCoin::getAvail(Parameters& params, std::string currency)
 {
   std::ostringstream oss;
   oss << "api_key=" << params.okcoinApi << "&secret_key=" << params.okcoinSecret;
@@ -65,7 +66,7 @@ double getAvail(Parameters& params, std::string currency)
   return availability;
 }
 
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair)
+std::string OKCoin::sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair)
 {
   // signature
   std::ostringstream oss;
@@ -85,7 +86,7 @@ std::string sendLongOrder(Parameters& params, std::string direction, double quan
   return orderId;
 }
 
-std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) {
+std::string OKCoin::sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) {
   // TODO
   // Unlike Bitfinex and Poloniex, on OKCoin the borrowing phase has to be done
   // as a separated step before being able to short sell.
@@ -100,7 +101,7 @@ std::string sendShortOrder(Parameters& params, std::string direction, double qua
   return "0";
 }
 
-bool isOrderComplete(Parameters& params, std::string orderId)
+bool OKCoin::isOrderComplete(Parameters& params, std::string orderId)
 {
   if (orderId == "0") return true;
 
@@ -119,9 +120,13 @@ bool isOrderComplete(Parameters& params, std::string orderId)
   return status == 2;
 }
 
-double getActivePos(Parameters& params, std::string currency) { return getAvail(params, "btc"); }
+//TODO: inline function
+double OKCoin::getActivePos(Parameters& params, std::string currency)
+{
+  return getAvail(params, "btc");
+}
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair)
+double OKCoin::getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair)
 {
   auto &exchange = queryHandle(params);
   unique_json root { exchange.getRequest("/api/v1/depth.do?symbol=btc_usd") };
@@ -149,7 +154,7 @@ double getLimitPrice(Parameters& params, double volume, bool isBid, std::string 
   return p;
 }
 
-json_t* authRequest(Parameters& params, std::string url, std::string signature, std::string content)
+json_t* OKCoin::authRequest(Parameters& params, std::string url, std::string signature, std::string content)
 {
   uint8_t digest[MD5_DIGEST_LENGTH];
   MD5((uint8_t *)signature.data(), signature.length(), (uint8_t *)&digest);
@@ -204,7 +209,7 @@ json_t* authRequest(Parameters& params, std::string url, std::string signature, 
   }
 }
 
-void getBorrowInfo(Parameters& params)
+void OKCoin::getBorrowInfo(Parameters& params)
 {
   std::ostringstream oss;
   oss << "api_key=" << params.okcoinApi << "&symbol=btc_usd&secret_key=" << params.okcoinSecret;
@@ -219,7 +224,7 @@ void getBorrowInfo(Parameters& params)
   free(dump);
 }
 
-int borrowBtc(Parameters& params, double amount)
+int OKCoin::borrowBtc(Parameters& params, double amount)
 {
   std::ostringstream oss;
   oss << "api_key=" << params.okcoinApi << "&symbol=btc_usd&days=fifteen&amount=" << 1 << "&rate=0.0001&secret_key=" << params.okcoinSecret;
@@ -240,7 +245,7 @@ int borrowBtc(Parameters& params, double amount)
          0;
 }
 
-void repayBtc(Parameters& params, int borrowId)
+void OKCoin::repayBtc(Parameters& params, int borrowId)
 {
   std::ostringstream oss;
   oss << "api_key=" << params.okcoinApi << "&borrow_id=" << borrowId << "&secret_key=" << params.okcoinSecret;
@@ -255,4 +260,4 @@ void repayBtc(Parameters& params, int borrowId)
   free(dump);
 }
 
-}
+} //namespace NSExchange

--- a/src/exchanges/okcoin.h
+++ b/src/exchanges/okcoin.h
@@ -1,36 +1,52 @@
+/*
+ * @file     okcoin.h
+ * @brief    Provides the interface to for exchanging using OkCoin.
+ */
+
 #ifndef OKCOIN_H
 #define OKCOIN_H
 
-#include "quote_t.h"
 #include <string>
+#include "iExchange.h"
+#include "quote_t.h"
+#include "utils/restapi.h"
+#include "unique_json.hpp"
 
-struct json_t;
-struct Parameters;
+namespace NSExchange
+{
 
-namespace OKCoin {
+/**
+ * @brief OKCoin is an implementation of IExchange interface. https://www.okcoin.com/
+ */
+class OKCoin : public IExchange
+{
+	virtual ~OKCoin() = default;
 
-quote_t getQuote(Parameters &params, std::string pair);
+	quote_t getQuote(Parameters &params, std::string pair) override final;
 
-double getAvail(Parameters& params, std::string currency);
+	double getAvail(Parameters& params, std::string currency) override final;
 
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-bool isOrderComplete(Parameters& params, std::string orderId);
+	bool isOrderComplete(Parameters& params, std::string orderId) override final;
 
-double getActivePos(Parameters& params, std::string currency);
+	double getActivePos(Parameters& params, std::string currency) override final;
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair);
+	double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) override final;
 
-json_t* authRequest(Parameters& params, std::string url, std::string signature, std::string content);
+	json_t* authRequest(Parameters& params, std::string url, std::string signature, std::string content);
 
-void getBorrowInfo(Parameters& params);
+	void getBorrowInfo(Parameters& params);
 
-int borrowBtc(Parameters& params, double amount);
+	int borrowBtc(Parameters& params, double amount);
 
-void repayBtc(Parameters& params, int borrowId);
+	void repayBtc(Parameters& params, int borrowId);
 
-}
+	static RestApi& queryHandle(Parameters &params);
+};
 
-#endif
+} //namespace NSExchange
+#endif /* OKCOIN_H */
+

--- a/src/exchanges/poloniex.cpp
+++ b/src/exchanges/poloniex.cpp
@@ -12,18 +12,17 @@
 #include <cctype>
 #include <iomanip>
 
-namespace Poloniex {
+namespace NSExchange
+{
 
-static json_t* authRequest(Parameters &, const char *, const std::string & = "");
-
-static RestApi& queryHandle(Parameters &params)
+RestApi& Poloniex::queryHandle(Parameters &params)
 {
   static RestApi query ("https://poloniex.com",
                         params.cacert.c_str(), *params.logFile);
   return query;
 }
 
-static json_t* checkResponse(std::ostream &logFile, json_t *root)
+json_t* Poloniex::checkResponse(std::ostream &logFile, json_t *root)
 {
   auto errmsg = json_object_get(root, "error");
   if (errmsg)
@@ -36,7 +35,7 @@ static json_t* checkResponse(std::ostream &logFile, json_t *root)
 
 // We use ETH/BTC as there is no USD on Poloniex
 // TODO We could show BTC/USDT
-quote_t getQuote(Parameters &params, std::string pair)
+quote_t Poloniex::getQuote(Parameters &params, std::string pair)
 {
   auto &exchange = queryHandle(params);
   unique_json root { exchange.getRequest("/public?command=returnTicker") };
@@ -50,7 +49,7 @@ quote_t getQuote(Parameters &params, std::string pair)
   return std::make_pair(bidValue, askValue);
 }
 
-double getAvail(Parameters &params, std::string currency)
+double Poloniex::getAvail(Parameters &params, std::string currency)
 {
   std::transform(begin(currency), end(currency), begin(currency), ::toupper);
   std::string options = "account=exchange";
@@ -62,7 +61,8 @@ double getAvail(Parameters &params, std::string currency)
   return funds ? std::stod(funds) : 0.0;
 }
 
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) {
+std::string Poloniex::sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair)
+{
   if (direction.compare("buy") != 0 && direction.compare("sell") != 0) {
     *params.logFile  << "<Poloniex> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
     return "0";
@@ -71,18 +71,19 @@ std::string sendLongOrder(Parameters& params, std::string direction, double quan
   std::string options = "currencyPair=USDT_BTC&rate=";
   std::string volume = std::to_string(quantity);
   std::string pricelimit = std::to_string(price);
-  options += pricelimit + "&amount=" + volume; 
+  options += pricelimit + "&amount=" + volume;
   unique_json root { authRequest(params, direction.c_str(), options) };
   std::string txid = json_string_value(json_object_get(root.get(),"orderNumber"));
   return txid;
 }
 
-std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) {
+std::string Poloniex::sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair)
+{
   // TODO
   return "0";
 }
 
-bool isOrderComplete(Parameters& params, std::string orderId)
+bool Poloniex::isOrderComplete(Parameters& params, std::string orderId)
 {
   unique_json root { authRequest(params, "returnOpenOrders", "currencyPair=USDT_BTC") };
   auto n = json_array_size(root.get());
@@ -95,7 +96,8 @@ bool isOrderComplete(Parameters& params, std::string orderId)
   return true;
 }
 
-double getActivePos(Parameters& params, std::string currency) {
+double Poloniex::getActivePos(Parameters& params, std::string currency)
+{
   // TODO: When we add the new getActivePos style uncomment this
   // double activeSize = 0.0;
   // if (!orderId.empty()){
@@ -118,7 +120,8 @@ double getActivePos(Parameters& params, std::string currency) {
   return getAvail(params, "BTC");
 }
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) {
+double Poloniex::getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair)
+{
   auto &exchange = queryHandle(params);
   // TODO: build real curr string
   //std::string uri = "/public?command=returnOrderBook&currencyPair=";
@@ -143,7 +146,7 @@ double getLimitPrice(Parameters& params, double volume, bool isBid, std::string 
   return p;
 }
 
-json_t* authRequest(Parameters &params, const char *request, const std::string &options)
+json_t* Poloniex::authRequest(Parameters &params, const char *request, const std::string &options)
 {
   using namespace std;
   static uint64_t nonce = time(nullptr) * 4;
@@ -170,5 +173,5 @@ json_t* authRequest(Parameters &params, const char *request, const std::string &
                                               make_slist(begin(headers), end(headers)),
                                               post_body));
 }
-  
-}
+
+} //namespace NEExchange

--- a/src/exchanges/poloniex.h
+++ b/src/exchanges/poloniex.h
@@ -16,8 +16,7 @@ namespace NSExchange
 {
 
 /**
- * @brief Poloniex is an implementation of IExchange interface that use Poloniex exchange
- *        URL: https://poloniex.com/
+ * @brief Poloniex is an implementation of IExchange interface. https://poloniex.com/
  */
 class Poloniex : public IExchange
 {

--- a/src/exchanges/poloniex.h
+++ b/src/exchanges/poloniex.h
@@ -1,27 +1,46 @@
+/*
+ * @file     poloniex.h
+ * @brief    Provides the interface to for exchanging using Poloniex.
+ */
+
 #ifndef POLONIEX_H
 #define POLONIEX_H
 
-#include "quote_t.h"
 #include <string>
+#include "iExchange.h"
+#include "quote_t.h"
+#include "utils/restapi.h"
+#include "unique_json.hpp"
 
-struct Parameters;
+namespace NSExchange
+{
 
-namespace Poloniex {
+/**
+ * @brief Poloniex is an implementation of IExchange interface that use Poloniex exchange
+ *        URL: https://poloniex.com/
+ */
+class Poloniex : public IExchange
+{
+	virtual ~Poloniex() = default;
 
-quote_t getQuote(Parameters &params, std::string pair);
+	quote_t getQuote(Parameters &params, std::string pair) override final;
 
-double getAvail(Parameters& params, std::string currency);
+	double getAvail(Parameters& params, std::string currency) override final;
 
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-bool isOrderComplete(Parameters& params, std::string orderId);
+	bool isOrderComplete(Parameters& params, std::string orderId) override final;
 
-double getActivePos(Parameters& params, std::string currency);
+	double getActivePos(Parameters& params, std::string currency) override final;
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair);
+	double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) override final;
 
-}
+	static json_t* authRequest(Parameters &, const char *, const std::string & = "");
+	static RestApi& queryHandle(Parameters &params);
+	static json_t* checkResponse(std::ostream &logFile, json_t *root);
+};
 
-#endif
+} //namespace NSExchange
+#endif /* POLONIEX_H */

--- a/src/exchanges/quadrigacx.h
+++ b/src/exchanges/quadrigacx.h
@@ -1,28 +1,50 @@
+/*
+ * @file     quadrigacx.h
+ * @brief    Provides the interface to for exchanging using QuadrigaCX.
+ */
+
 #ifndef QUADRIGACX_H
 #define QUADRIGACX_H
 
-#include "quote_t.h"
 #include <string>
 #include <sstream>
+#include "iExchange.h"
+#include "quote_t.h"
+#include "utils/restapi.h"
+#include "unique_json.hpp"
 
-struct json_t;
-struct Parameters;
+namespace NSExchange
+{
 
-namespace QuadrigaCX {
+/**
+ * @brief QuadrigaCX is an implementation of IExchange interface that use QuadrigaCX exchange
+ *        URL: https://www.quadrigacx.com
+ */
+class QuadrigaCX : public IExchange
+{
+	virtual ~QuadrigaCX() = default;
 
-quote_t getQuote(Parameters &params, std::string pair);
+	quote_t getQuote(Parameters &params, std::string pair) override final;
 
-double getAvail(Parameters& params, std::string currency);
+	double getAvail(Parameters& params, std::string currency) override final;
 
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price, std::string pair) override final;
 
-bool isOrderComplete(Parameters& params, std::string orderId);
+	std::string sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair) override final;
 
-double getActivePos(Parameters& params, std::string currency);
+	bool isOrderComplete(Parameters& params, std::string orderId) override final;
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair);
+	double getActivePos(Parameters& params, std::string currency) override final;
 
-void testQuadriga();
-}
+	double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) override final;
 
-#endif
+	void testQuadriga();
+
+	static std::string getSignature(Parameters& params, const uint64_t nonce);
+	static json_t* authRequest(Parameters& params, std::string request, json_t * options = nullptr);
+	static RestApi& queryHandle(Parameters &params);
+
+};
+
+} //namespace NSExchange
+#endif /* QUADRIGACX_H */

--- a/src/exchanges/quadrigacx.h
+++ b/src/exchanges/quadrigacx.h
@@ -17,8 +17,7 @@ namespace NSExchange
 {
 
 /**
- * @brief QuadrigaCX is an implementation of IExchange interface that use QuadrigaCX exchange
- *        URL: https://www.quadrigacx.com
+ * @brief QuadrigaCX is an implementation of IExchange interface. https://www.quadrigacx.com
  */
 class QuadrigaCX : public IExchange
 {

--- a/src/exchanges/wex.h
+++ b/src/exchanges/wex.h
@@ -16,8 +16,7 @@ namespace NSExchange
 {
 
 /**
- * @brief WEX is an implementation of IExchange interface that use WEX exchange
- *        URL: https://wex.nz
+ * @brief WEX is an implementation of IExchange interface. https://wex.nz
  */
 class WEX : public IExchange
 {

--- a/src/exchanges/wex.h
+++ b/src/exchanges/wex.h
@@ -1,25 +1,47 @@
+/*
+ * @file     wex.h
+ * @brief    Provides the interface to for exchanging using WEX.
+ */
+
 #ifndef WEX_H
 #define WEX_H
 
-#include "quote_t.h"
 #include <string>
+#include "iExchange.h"
+#include "quote_t.h"
+#include "utils/restapi.h"
+#include "unique_json.hpp"
 
-struct Parameters;
+namespace NSExchange
+{
 
-namespace WEX {
+/**
+ * @brief WEX is an implementation of IExchange interface that use WEX exchange
+ *        URL: https://wex.nz
+ */
+class WEX : public IExchange
+{
+	virtual ~WEX() = default;
 
-quote_t getQuote(Parameters &params, std::string pair);
+	quote_t getQuote(Parameters &params, std::string pair) override final;
 
-double getAvail(Parameters& params, std::string currency);
+	double getAvail(Parameters& params, std::string currency) override final;
 
-std::string sendLongOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair);
+	std::string sendLongOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair) override final;
 
-bool isOrderComplete(Parameters& params, std::string orderId);
+	std::string sendShortOrder(Parameters &params, std::string direction, double quantity, double price, std::string pair) override final;
 
-double getActivePos(Parameters& params, std::string currency);
+	bool isOrderComplete(Parameters& params, std::string orderId) override final;
 
-double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair);
+	double getActivePos(Parameters& params, std::string currency) override final;
 
-}
+	double getLimitPrice(Parameters& params, double volume, bool isBid, std::string pair) override final;
 
-#endif
+	static json_t* authRequest(Parameters &, const char *, const std::string & = "");
+	static json_t* adjustResponse(json_t *);
+	static RestApi& queryHandle(Parameters &params);
+	static json_t* checkResponse(std::ostream &logFile, json_t *root);
+};
+
+} //namespace NSExchange
+#endif /* WEX_H */


### PR DESCRIPTION
This is a code refactoring PR that include the following points:

- Add an `IExchange` interface 
- Update each exchange using the `IExchange` interface
- Remove function pointers in `main.cpp` file (type definitions and arrays initializations)
- Create a vector of `IExchange` pointers and initialize it with each exchange
- Use pointer interface to call each old function pointer

I've moved code from one site to other in order to do a bit of design and trying to modularize the big main function. :hammer: 

:notebook:  **NOTE**: I didn't consider const-correctness (yet)
