### PR TITLE
Remove in market logic 

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,6 @@
 #include <chrono>
 #include <thread>
 #include <cmath>
-#include <algorithm>
 #include <string>
 
 #include "bitcoin.h"
@@ -111,38 +110,19 @@ int main(int argc, char** argv)
     logFile << "   WARNING: Spread Target should be positive" << std::endl;
   }
   logFile << std::endl;
-  logFile << "[ Current balances ]" << std::endl;
 
   //*************************************************************************************
   // Gets the the balances from every exchange. This is only done when not in Demo mode.
   //*************************************************************************************
   NSMop::Balances balance(numExch);
-  if (!params.isDemoMode) {
-    std::transform(exchanges.begin(), exchanges.end(),
-                   balance.begin(),
-                   [&params](NSExchange::IExchange* exchange)
-                   {
-                     NSMop::Balance tmp {};
+  NSMop::getExchangeBalances(exchanges,params, balance);
+  NSMop::logCurrentBalances(params, balance, numExch, logFile);
 
-                     std::string leg1Lower = NSMop::str_tolower(params.leg1);
-                     std::string leg2Lower = NSMop::str_tolower(params.leg2);
-
-
-                     tmp.leg1 = exchange->getAvail(params, leg1Lower);
-                     tmp.leg2 = exchange->getAvail(params, leg2Lower);
-                     return tmp;
-                   } );
-  }
-
-  std::string pair = NSMop::str_tolower(params.leg1 + params.leg2);
-  // logFile << "pair = " << pair;
+  const std::string pair { NSMop::str_tolower(params.leg1 + params.leg2) };
 
   // Checks for a restore.txt file, to see if the program exited with an open position.
   Result res;
-  res.reset();
-  bool inMarket = res.loadPartialResult("restore.txt");
-
-  NSMop::logCurrentBalances(params, balance, numExch, inMarket, logFile);
+  res.reset(); //TODO: checks if this reset is really necessary
 
   // Code implementing the loop function, that runs every 'Interval' seconds.
   time_t rawtime = time(nullptr);
@@ -186,11 +166,7 @@ int main(int argc, char** argv)
     }
     // Header for every iteration of the loop
     if (params.verbose) {
-      if (!inMarket) {
-        logFile << "[ " << printDateTime(currTime) << " ]" << std::endl;
-      } else {
-        logFile << "[ " << printDateTime(currTime) << " IN MARKET: Long " << res.exchNameLong << " / Short " << res.exchNameShort << " ]" << std::endl;
-      }
+      logFile << "[ " << printDateTime(currTime) << " ]" << std::endl;
     }
 
     //*********************************************************************************
@@ -249,222 +225,116 @@ int main(int argc, char** argv)
     //*********************************************************************************
     // Looks for arbitrage opportunities on all the exchange combinations
     //*********************************************************************************
-    if (!inMarket)
-    {
-      for (int i = 0; i < numExch; ++i) {
-        for (int j = 0; j < numExch; ++j) {
-          if (i != j) {
-            if (checkEntry(&btcVec[i], &btcVec[j], res, params)) {
-              //*********************************************************************************
-              // An entry opportunity has been found!
-              //*********************************************************************************
-              res.exposure = std::min(balance[res.idExchLong].leg2, balance[res.idExchShort].leg2);
-              if (params.isDemoMode) {
-                logFile << "INFO: Opportunity found but no trade will be generated (Demo mode)" << std::endl;
-                break;
-              }
-              if (res.exposure == 0.0) {
-                logFile << "WARNING: Opportunity found but no cash available. Trade canceled" << std::endl;
-                break;
-              }
-              if (params.useFullExposure == false && res.exposure <= params.testedExposure) {
-                logFile << "WARNING: Opportunity found but no enough cash. Need more than TEST cash (min. $"
-                        << std::setprecision(2) << params.testedExposure << "). Trade canceled" << std::endl;
-                break;
-              }
-              if (params.useFullExposure) {
-                // Removes 1% of the exposure to have
-                // a little bit of margin.
-                res.exposure -= 0.01 * res.exposure;
-                if (res.exposure > params.maxExposure) {
-                  logFile << "WARNING: Opportunity found but exposure ("
-                          << std::setprecision(2)
-                          << res.exposure << ") above the limit\n"
-                          << "         Max exposure will be used instead (" << params.maxExposure << ")" << std::endl;
-                  res.exposure = params.maxExposure;
-                }
-              } else {
-                res.exposure = params.testedExposure;
-              }
-              // Checks the volumes and, based on that, computes the limit prices
-              // that will be sent to the exchanges
-              double volumeLong = res.exposure / btcVec[res.idExchLong].getAsk();
-              double volumeShort = res.exposure / btcVec[res.idExchShort].getBid();
-              double limPriceLong = exchanges[res.idExchLong]->getLimitPrice(params, volumeLong, false, pair);
-              double limPriceShort = exchanges[res.idExchShort]->getLimitPrice(params, volumeShort, true, pair);
-              if (limPriceLong == 0.0 || limPriceShort == 0.0) {
-                logFile << "WARNING: Opportunity found but error with the order books (limit price is null). Trade canceled\n";
-                logFile.precision(2);
-                logFile << "         Long limit price:  " << limPriceLong << std::endl;
-                logFile << "         Short limit price: " << limPriceShort << std::endl;
-                res.trailing[res.idExchLong][res.idExchShort] = -1.0;
-                break;
-              }
-              if (limPriceLong - res.priceLongIn > params.priceDeltaLim || res.priceShortIn - limPriceShort > params.priceDeltaLim) {
-                logFile << "WARNING: Opportunity found but not enough liquidity. Trade canceled\n";
-                logFile.precision(2);
-                logFile << "         Target long price:  " << res.priceLongIn << ", Real long price:  " << limPriceLong << std::endl;
-                logFile << "         Target short price: " << res.priceShortIn << ", Real short price: " << limPriceShort << std::endl;
-                res.trailing[res.idExchLong][res.idExchShort] = -1.0;
-                break;
-              }
-              // We are in market now, meaning we have positions on leg1 (the hedged on)
-              // We store the details of that first trade into the Result structure.
-              inMarket = true;
-              resultId++;
-              res.id = resultId;
-              res.entryTime = currTime;
-              res.priceLongIn = limPriceLong;
-              res.priceShortIn = limPriceShort;
-              res.printEntryInfo(*params.logFile);
-              res.maxSpread[res.idExchLong][res.idExchShort] = -1.0;
-              res.minSpread[res.idExchLong][res.idExchShort] = 1.0;
-              res.trailing[res.idExchLong][res.idExchShort] = 1.0;
-
-              // Send the orders to the two exchanges
-              auto longOrderId = exchanges[res.idExchLong]->sendLongOrder(params, "buy", volumeLong, limPriceLong, pair);
-              auto shortOrderId = exchanges[res.idExchShort]->sendShortOrder(params, "sell", volumeShort, limPriceShort, pair);
-              logFile << "Waiting for the two orders to be filled... Long: " << longOrderId << " - Short: " << shortOrderId << std::endl;
-              //TODO if orderId == 0 there was an error, we should rollback both
-
-              sleep_for(millisecs(5000));
-              bool isLongOrderComplete = exchanges[res.idExchLong]->isOrderComplete(params, longOrderId);
-              bool isShortOrderComplete = exchanges[res.idExchShort]->isOrderComplete(params, shortOrderId);
-              // Loops until both orders are completed
-              while (!isLongOrderComplete || !isShortOrderComplete) {
-                sleep_for(millisecs(3000));
-                if (!isLongOrderComplete) {
-                  logFile << "Long order on " << params.exchName[res.idExchLong] << " still open..." << std::endl;
-                  isLongOrderComplete = exchanges[res.idExchLong]->isOrderComplete(params, longOrderId);
-                }
-                if (!isShortOrderComplete) {
-                  logFile << "Short order on " << params.exchName[res.idExchShort] << " still open..." << std::endl;
-                  isShortOrderComplete = exchanges[res.idExchShort]->isOrderComplete(params, shortOrderId);
-                }
-              }
-              // Both orders are now fully executed
-              logFile << "Done" << std::endl;
-
-              // Stores the partial result to file in case
-              // the program exits before closing the position.
-              res.savePartialResult("restore.txt");
-
-              // Resets the order ids
-              longOrderId  = "0";
-              shortOrderId = "0";
+    for (int i = 0; i < numExch; ++i) {
+      for (int j = 0; j < numExch; ++j) {
+        if (i != j) {
+          if (checkEntry(&btcVec[i], &btcVec[j], res, params)) {
+            //*********************************************************************************
+            // An entry opportunity has been found!
+            //*********************************************************************************
+            res.exposure = std::min(balance[res.idExchLong].leg2, balance[res.idExchShort].leg2);
+            if (params.isDemoMode) {
+              logFile << "INFO: Opportunity found but no trade will be generated (Demo mode)" << std::endl;
               break;
             }
-          }
-        } //end nested for
-        if (inMarket) {
-          break;
-        }
-      } // end first for
-      if (params.verbose) {
-        logFile << std::endl;
-      }
-    } else if (inMarket) {
-      // We are in market and looking for an exit opportunity
-      if (checkExit(&btcVec[res.idExchLong], &btcVec[res.idExchShort], res, params, currTime)) {
-        //*********************************************************************************
-        // An exit opportunity has been found!
-        //*********************************************************************************
-        // We check the current leg1 exposure
-        std::vector<double> btcUsed(numExch);
-        for (int i = 0; i < numExch; ++i) {
-          btcUsed[i] = exchanges[i]->getActivePos(params, NSMop::str_tolower(params.leg1));
-        }
-        // Checks the volumes and computes the limit prices that will be sent to the exchanges
-        double volumeLong = btcUsed[res.idExchLong];
-        double volumeShort = btcUsed[res.idExchShort];
-        double limPriceLong = exchanges[res.idExchLong]->getLimitPrice(params, volumeLong, true, pair);
-        double limPriceShort = exchanges[res.idExchShort]->getLimitPrice(params, volumeShort, false, pair);
-        if (limPriceLong == 0.0 || limPriceShort == 0.0) {
-          logFile << "WARNING: Opportunity found but error with the order books (limit price is null). Trade canceled\n";
-          logFile.precision(2);
-          logFile << "         Long limit price:  " << limPriceLong << std::endl;
-          logFile << "         Short limit price: " << limPriceShort << std::endl;
-          res.trailing[res.idExchLong][res.idExchShort] = 1.0;
-        } else if (res.priceLongOut - limPriceLong > params.priceDeltaLim || limPriceShort - res.priceShortOut > params.priceDeltaLim) {
-          logFile << "WARNING: Opportunity found but not enough liquidity. Trade canceled\n";
-          logFile.precision(2);
-          logFile << "         Target long price:  " << res.priceLongOut << ", Real long price:  " << limPriceLong << std::endl;
-          logFile << "         Target short price: " << res.priceShortOut << ", Real short price: " << limPriceShort << std::endl;
-          res.trailing[res.idExchLong][res.idExchShort] = 1.0;
-        } else {
-          res.exitTime = currTime;
-          res.priceLongOut = limPriceLong;
-          res.priceShortOut = limPriceShort;
-          res.printExitInfo(*params.logFile);
-
-          logFile.precision(6);
-          logFile << params.leg1 << " exposure on " << params.exchName[res.idExchLong] << ": " << volumeLong << '\n'
-                  << params.leg1 << " exposure on " << params.exchName[res.idExchShort] << ": " << volumeShort << '\n'
-                  << std::endl;
-          auto longOrderId = exchanges[res.idExchLong]->sendLongOrder(params, "sell", fabs(btcUsed[res.idExchLong]), limPriceLong, pair);
-          auto shortOrderId = exchanges[res.idExchShort]->sendShortOrder(params, "buy", fabs(btcUsed[res.idExchShort]), limPriceShort, pair);
-          logFile << "Waiting for the two orders to be filled..." << std::endl;
-          sleep_for(millisecs(5000));
-          bool isLongOrderComplete = exchanges[res.idExchLong]->isOrderComplete(params, longOrderId);
-          bool isShortOrderComplete = exchanges[res.idExchShort]->isOrderComplete(params, shortOrderId);
-          // Loops until both orders are completed
-          while (!isLongOrderComplete || !isShortOrderComplete) {
-            sleep_for(millisecs(3000));
-            if (!isLongOrderComplete) {
-              logFile << "Long order on " << params.exchName[res.idExchLong] << " still open..." << std::endl;
-              isLongOrderComplete = exchanges[res.idExchLong]->isOrderComplete(params, longOrderId);
+            if (res.exposure == 0.0) {
+              logFile << "WARNING: Opportunity found but no cash available. Trade canceled" << std::endl;
+              break;
             }
-            if (!isShortOrderComplete) {
-              logFile << "Short order on " << params.exchName[res.idExchShort] << " still open..." << std::endl;
-              isShortOrderComplete = exchanges[res.idExchShort]->isOrderComplete(params, shortOrderId);
+            if (params.useFullExposure == false && res.exposure <= params.testedExposure) {
+              logFile << "WARNING: Opportunity found but no enough cash. Need more than TEST cash (min. $"
+                      << std::setprecision(2) << params.testedExposure << "). Trade canceled" << std::endl;
+              break;
             }
-          }
-          logFile << "Done\n" << std::endl;
-          longOrderId  = "0";
-          shortOrderId = "0";
-          inMarket = false;
-          for (int i = 0; i < numExch; ++i) {
-            std::string leg1AfterLower = NSMop::str_tolower(params.leg1);
-            std::string leg2AfterLower = NSMop::str_tolower(params.leg2);
+            if (params.useFullExposure) {
+              // Removes 1% of the exposure to have
+              // a little bit of margin.
+              res.exposure -= 0.01 * res.exposure;
+              if (res.exposure > params.maxExposure) {
+                logFile << "WARNING: Opportunity found but exposure ("
+                        << std::setprecision(2)
+                        << res.exposure << ") above the limit\n"
+                        << "         Max exposure will be used instead (" << params.maxExposure << ")" << std::endl;
+                res.exposure = params.maxExposure;
+              }
+            } else {
+              res.exposure = params.testedExposure;
+            }
+            // Checks the volumes and, based on that, computes the limit prices
+            // that will be sent to the exchanges
+            double volumeLong = res.exposure / btcVec[res.idExchLong].getAsk();
+            double volumeShort = res.exposure / btcVec[res.idExchShort].getBid();
+            double limPriceLong = exchanges[res.idExchLong]->getLimitPrice(params, volumeLong, false, pair);
+            double limPriceShort = exchanges[res.idExchShort]->getLimitPrice(params, volumeShort, true, pair);
+            if (limPriceLong == 0.0 || limPriceShort == 0.0) {
+              logFile << "WARNING: Opportunity found but error with the order books (limit price is null). Trade canceled\n";
+              logFile.precision(2);
+              logFile << "         Long limit price:  " << limPriceLong << std::endl;
+              logFile << "         Short limit price: " << limPriceShort << std::endl;
+              res.trailing[res.idExchLong][res.idExchShort] = -1.0;
+              break;
+            }
+            if (limPriceLong - res.priceLongIn > params.priceDeltaLim || res.priceShortIn - limPriceShort > params.priceDeltaLim) {
+              logFile << "WARNING: Opportunity found but not enough liquidity. Trade canceled\n";
+              logFile.precision(2);
+              logFile << "         Target long price:  " << res.priceLongIn << ", Real long price:  " << limPriceLong << std::endl;
+              logFile << "         Target short price: " << res.priceShortIn << ", Real short price: " << limPriceShort << std::endl;
+              res.trailing[res.idExchLong][res.idExchShort] = -1.0;
+              break;
+            }
+            // We are in market now, meaning we have positions on leg1 (the hedged on)
+            // We store the details of that first trade into the Result structure.
+            //inMarket = true;
+            resultId++;
+            res.id = resultId;
+            res.entryTime = currTime;
+            res.priceLongIn = limPriceLong;
+            res.priceShortIn = limPriceShort;
+            res.printEntryInfo(*params.logFile);
+            res.maxSpread[res.idExchLong][res.idExchShort] = -1.0;
+            res.minSpread[res.idExchLong][res.idExchShort] = 1.0;
+            res.trailing[res.idExchLong][res.idExchShort] = 1.0;
 
-            balance[i].leg2After = exchanges[i]->getAvail(params, leg2AfterLower);
-            balance[i].leg1After = exchanges[i]->getAvail(params, leg1AfterLower);
-          }
-          for (int i = 0; i < numExch; ++i) {
-            logFile << "New balance on " << params.exchName[i] << ":  \t";
-            logFile.precision(2);
-            logFile << balance[i].leg2After << " " << params.leg2 << " (perf " << balance[i].leg2After - balance[i].leg2 << "), ";
-            logFile << std::setprecision(6) << balance[i].leg1After << " " << params.leg1 << "\n";
-          }
-          logFile << std::endl;
-          // Update total leg2 balance
-          for (int i = 0; i < numExch; ++i) {
-            res.leg2TotBalanceBefore += balance[i].leg2;
-            res.leg2TotBalanceAfter  += balance[i].leg2After;
-          }
-          // Update current balances
-          for (int i = 0; i < numExch; ++i) {
-            balance[i].leg2 = balance[i].leg2After;
-            balance[i].leg1 = balance[i].leg1After;
-          }
-          // Prints the result in the result CSV file
-          logFile.precision(2);
-          logFile << "ACTUAL PERFORMANCE: " << "$" << res.leg2TotBalanceAfter - res.leg2TotBalanceBefore << " (" << res.actualPerf() * 100.0 << "%)\n" << std::endl;
-          csvFile.save(res);
+            // Send the orders to the two exchanges
+            auto longOrderId = exchanges[res.idExchLong]->sendLongOrder(params, "buy", volumeLong, limPriceLong, pair);
+            auto shortOrderId = exchanges[res.idExchShort]->sendShortOrder(params, "sell", volumeShort, limPriceShort, pair);
+            logFile << "Waiting for the two orders to be filled... Long: " << longOrderId << " - Short: " << shortOrderId << std::endl;
+            //TODO if orderId == 0 there was an error, we should rollback both
 
-          // Sends an email with the result of the trade
-          if (params.sendEmail) {
-            sendEmail(res, params);
-            logFile << "Email sent" << std::endl;
+            sleep_for(millisecs(5000));
+            bool isLongOrderComplete = exchanges[res.idExchLong]->isOrderComplete(params, longOrderId);
+            bool isShortOrderComplete = exchanges[res.idExchShort]->isOrderComplete(params, shortOrderId);
+            // Loops until both orders are completed
+            while (!isLongOrderComplete || !isShortOrderComplete) {
+              sleep_for(millisecs(3000));
+              if (!isLongOrderComplete) {
+                logFile << "Long order on " << params.exchName[res.idExchLong] << " still open..." << std::endl;
+                isLongOrderComplete = exchanges[res.idExchLong]->isOrderComplete(params, longOrderId);
+              }
+              if (!isShortOrderComplete) {
+                logFile << "Short order on " << params.exchName[res.idExchShort] << " still open..." << std::endl;
+                isShortOrderComplete = exchanges[res.idExchShort]->isOrderComplete(params, shortOrderId);
+              }
+            }
+            // Both orders are now fully executed
+            logFile << "Done" << std::endl;
+
+            // Resets the order ids
+            longOrderId  = "0";
+            shortOrderId = "0";
+            break;
           }
-          res.reset();
-          // Removes restore.txt since this trade is done.
-          std::ofstream resFile("restore.txt", std::ofstream::trunc);
-          resFile.close();
         }
-      }
-      if (params.verbose) logFile << '\n';
+      } //end nested for
+    } // end first for
+    if (params.verbose) {
+      logFile << std::endl;
     }
+
+    /****************************************************************************
+    // TODO: account rebalance
+    ****************************************************************************/
+
     // Moves to the next iteration, unless
     // the maxmum is reached.
     timeinfo.tm_sec += params.interval;
@@ -477,7 +347,7 @@ int main(int argc, char** argv)
     // Warning: by default on GitHub the file has a underscore
     // at the end, so Blackbird is not stopped by default.
     std::ifstream infile("stop_after_notrade");
-    if (infile && !inMarket) {
+    if (infile) {
       logFile << "Exit after last trade (file stop_after_notrade found)\n";
       stillRunning = false;
     }

--- a/src/mop.h
+++ b/src/mop.h
@@ -73,16 +73,24 @@ void demoModeAssert(const Parameters& params);
 void initializeExchages(Parameters& params, NSExchange::Exchanges& exchanges, std::string* dbTableName);
 
 /**
+ * @brief Gets the the balances from every exchange. This is only done when not in Demo mode.
+ *
+ * @param params[in]: hold the exchanges information
+ * @param params[out]: hold the exchanges information
+ * @param balance[out]: to fill with the exchange balances
+ */
+void getExchangeBalances(const NSExchange::Exchanges& exchanges, Parameters& params, NSMop::Balances& balance);
+
+/**
  * @brief Writes the current balances into the log file
  *
  * @param balance[in]: the exchanges balance container
  * @param params[in]: hold the exchanges information
  * @param numExch[in]: amount of exchanges availables
- * @param inMarket[in]: inMarket boolean
  * @param logFile[out]: the log file reference
  */
 void logCurrentBalances(const Parameters& params, const NSMop::Balances& balance, const size_t numExch,
-						const bool inMarket, std::ofstream& logFile);
+						std::ofstream& logFile);
 
 } //namspace NSMop
 #endif /* MOP_H */


### PR DESCRIPTION
This PR involves the following items:

- move get exchange balanace login into mop file (refactor to modularize main file)
- remove big inMarket conditional
- remove exit operation 
- remove temporal saving on restore.txt

The :new: logic in general is:
```
get_exchange_balance
while(stillRunning)
      get_bid_and_ask
      looking_for_opportunity
```
